### PR TITLE
Add getEntryCount to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ const files = await strapi.upload(form, {
 ### `clearToken(token)`
 ### `getEntries(contentTypePluralized, params)`
 ### `getEntry(contentTypePluralized, id)`
+### `getEntryCount(contentTypePluralized, params)`
 ### `createEntry(contentTypePluralized, data)`
 ### `updateEntry(contentTypePluralized, id, data)`
 ### `deleteEntry(contentTypePluralized, id)`


### PR DESCRIPTION
Thanks to [this pull request](https://github.com/strapi/strapi-sdk-javascript/pull/27), it is now possible to get the count of entries. It would be great if the README could reflect this

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updating doc


* **What is the current behavior?** (You can also link to an open issue here)
No doc for the method getEntryCount [added by PR](https://github.com/strapi/strapi-sdk-javascript/pull/27)


* **What is the new behavior (if this is a feature change)?**
Added the line to the README


* **Other information**:
