### PR TITLE
[FIX] Allow array filters in get requests

### DIFF
--- a/src/lib/sdk.ts
+++ b/src/lib/sdk.ts
@@ -237,7 +237,9 @@ export default class Strapi {
     params?: AxiosRequestConfig['params']
   ): Promise<object[]> {
     return this.request('get', `/${contentTypePluralized}`, {
-      params
+      params,
+      paramsSerializer: (pars?: AxiosRequestConfig['params']) =>
+        qs.stringify(pars, { arrayFormat: 'repeat' })
     });
   }
 
@@ -251,7 +253,9 @@ export default class Strapi {
     params?: AxiosRequestConfig['params']
   ): Promise<object[]> {
     return this.request('get', `/${contentType}/count`, {
-      params
+      params,
+      paramsSerializer: (pars?: AxiosRequestConfig['params']) =>
+        qs.stringify(pars, { arrayFormat: 'repeat' })
     });
   }
 
@@ -321,7 +325,9 @@ export default class Strapi {
    */
   public getFiles(params?: AxiosRequestConfig['params']): Promise<object[]> {
     return this.request('get', '/upload/files', {
-      params
+      params,
+      paramsSerializer: (pars?: AxiosRequestConfig['params']) =>
+        qs.stringify(pars, { arrayFormat: 'repeat' })
     });
   }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix : allow array filtering while requesting entries

Arrays are sent to strapi with multiple parameters with the same name (not suffixed with [xxx])

Actually, you can't send to strapi the following request using the sdk : http://localhost:1337/themes?tags_in=2&tags_in=1

With this PR, you can : 
```
  strapi.getEntries("themes", { tags_in: [2,1] })
```

* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/strapi/strapi-sdk-javascript/issues/67


* **What is the new behavior (if this is a feature change)?**

Multiple params with the same name are sent to strapi, allowing filters like **in** 


 

