### PR TITLE
Return resetPassword and forgotPassword response

### DIFF
--- a/src/lib/sdk.ts
+++ b/src/lib/sdk.ts
@@ -163,9 +163,9 @@ export default class Strapi {
    * @param email
    * @param url Link that user will receive.
    */
-  public async forgotPassword(email: string, url: string): Promise<void> {
+  public async forgotPassword(email: string, url: string): Promise<Object> {
     this.clearToken();
-    await this.request('post', '/auth/forgot-password', {
+    return this.request('post', '/auth/forgot-password', {
       data: {
         email,
         url
@@ -183,9 +183,9 @@ export default class Strapi {
     code: string,
     password: string,
     passwordConfirmation: string
-  ): Promise<void> {
+  ): Promise<Authentication> {
     this.clearToken();
-    await this.request('post', '/auth/reset-password', {
+    return this.request('post', '/auth/reset-password', {
       data: {
         code,
         password,


### PR DESCRIPTION
It is more than important to process the response from these two requests because they can either contain an important error to display, or better: resetPassword even gives me jwt + user object back, which I can use to immediately set the cookie.

I am not sure if some other documentation has to be updated, AFAIK everything is read from the TS definitions.
Thanks in advance.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
